### PR TITLE
3 minutes is too short on fargate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,11 @@ locals {
 resource "k8s_manifest" "resource" {
   count = length(local.resources)
 
+  timeouts  {
+    create = "5m"
+    delete = "5m"
+  }
+  
   namespace = var.namespace
   content   = local.resources[count.index]
 


### PR DESCRIPTION
I've been unable to deploy this on an EKS fargate cluster as deployment for the redis ha always takes a little bit longer than 3 minutes.
The banzai k8s provider you are using defaults to 3 minutes, the next version of that provider will default to 5 minutes (yet to be tagged).

